### PR TITLE
Fix Timestamp precision from second to millisecond

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## Unreleased
 
+### Fixed
+- Timestamp precision from second to millisecond
+
 ## [0.5.0] - 2021-10-18
 
 ### Added

--- a/main.go
+++ b/main.go
@@ -226,7 +226,7 @@ func executeCheck(event *types.Event) (int, error) {
 		warnings  int
 	)
 
-	timeNow := time.Now().Unix()
+	timeNow := time.Now().UnixNano() / 1000000
 	parts, err := disk.Partitions(plugin.IncludePseudo)
 	if err != nil {
 		return sensu.CheckStateCritical, fmt.Errorf("Failed to get partitions, error: %v", err)


### PR DESCRIPTION
The timestamp used to output the Check Result in `prometheus_text` format should be millisecond precision or it will not be transformed correctly.

```
# HELP disk_percent_usage [GAUGE] Percentage of mounted volume used
# TYPE disk_percent_usage GAUGE
disk_percent_usage{mountpoint="/"} 22.715118440435823 1643744500
```

```
# event.metrics.points
      {
        "name": "disk_percent_usage",
        "value": 10.450136194340987,
        "timestamp": 1643744, # -> 1970-01-20
        "tags": [
          {
            "name": "mountpoint",
            "value": "/"
          },
          {
            "name": "prom_type",
            "value": "gauge"
          }
        ]
      },
```

According to the [Prometheus Exposition Format](https://prometheus.io/docs/instrumenting/exposition_formats/), timestamp precision is required to be in milliseconds.
